### PR TITLE
Improve keep columns

### DIFF
--- a/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/Transform.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/Transform.groovy
@@ -596,8 +596,10 @@ IProcess extractRelationsAsLines() {
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
                     warn "No keys or values found in the relations. An empty table will be returned."
-                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
-                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    datasource.execute """
+                            DROP TABLE IF EXISTS $outputTableName;
+                            CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                    """
                     return [outputTableName: outputTableName]
                 }
                 def relationsLinesTmp = "RELATIONS_LINES_TMP_$uuid"
@@ -618,8 +620,11 @@ IProcess extractRelationsAsLines() {
                 }
 
                 if(columnsToKeep){
-                    if(datasource.firstRow("""SELECT count(*) as count FROM $RelationsFilteredKeys AS a, 
-                ${osmTablesPrefix}_RELATION_TAG AS b WHERE a.ID_RELATION = b.ID_RELATION AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                    if(datasource.firstRow("""
+                            SELECT count(*) AS count 
+                            FROM $RelationsFilteredKeys AS a, ${osmTablesPrefix}_RELATION_TAG AS b 
+                            WHERE a.ID_RELATION = b.ID_RELATION AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')
+                        """)[0] < 1){
                         info "Any columns to keep. Cannot create any geometry lines. An empty table will be returned."
                         datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
                         CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""

--- a/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/Transform.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/Transform.groovy
@@ -175,8 +175,10 @@ IProcess extractWaysAsPolygons() {
                 def tagsFilter = createWhereFilter(tags)
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
-                    warn "No keys or values found to extract ways."
-                    return
+                    warn "No keys or values found to extract ways. An empty table will be returned."
+                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    return [outputTableName: outputTableName]
                 }
 
                 info "Build way polygons"
@@ -196,6 +198,15 @@ IProcess extractWaysAsPolygons() {
                 else{
                     idWaysPolygons = osmTableTag
                 }
+
+                if(columnsToKeep){
+                    if(datasource.firstRow("""SELECT count(*) as count FROM $idWaysPolygons AS a, 
+                ${osmTablesPrefix}_WAY_TAG AS b WHERE a.ID_WAY = b.ID_WAY AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                        info "Any columns to keep. Cannot create any geometry polygons. An empty table will be returned."
+                        datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                        return [outputTableName: outputTableName]
+                    }}
 
                 datasource.execute """
                         CREATE TABLE $waysPolygonTmp AS
@@ -270,8 +281,10 @@ IProcess extractRelationsAsPolygons() {
                 def tagsFilter = createWhereFilter(tags)
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
-                    warn "No keys or values found in the relations."
-                    return
+                    warn "No keys or values found in the relations. An empty table will be returned."
+                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    return [outputTableName: outputTableName]
                 }
                 info "Build outer polygons"
                 def relationsPolygonsOuter = "RELATIONS_POLYGONS_OUTER_$uuid"
@@ -291,6 +304,16 @@ IProcess extractRelationsAsPolygons() {
                                 WHERE $tagsFilter;
                             CREATE INDEX ON $relationFilteredKeys(id_relation);
                     """
+
+                    if(columnsToKeep){
+                        if(datasource.firstRow("""SELECT count(*) as count FROM $relationFilteredKeys AS a, 
+                ${osmTablesPrefix}_RELATION_TAG AS b WHERE a.ID_RELATION = b.ID_RELATION AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                            info "Any columns to keep. Cannot create any geometry polygons. An empty table will be returned."
+                            datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                            return [outputTableName: outputTableName]
+                        }}
+
                     outer_condition = """, $relationFilteredKeys g 
                             WHERE br.id_relation=g.id_relation
                             AND w.id_way = br.id_way
@@ -451,8 +474,10 @@ IProcess extractWaysAsLines() {
                 def tagsFilter = createWhereFilter(tags)
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
-                    info "No keys or values found in the ways."
-                    return
+                    info "No keys or values found in the ways. An empty table will be returned."
+                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    return [outputTableName: outputTableName]
                 }
                 info "Build ways as lines"
                 def waysLinesTmp = "WAYS_LINES_TMP_$uuid"
@@ -470,6 +495,16 @@ IProcess extractWaysAsLines() {
                             CREATE INDEX ON $idWaysTable(id_way);
                     """
                 }
+
+                if(columnsToKeep){
+                    if(datasource.firstRow("""SELECT count(*) as count FROM $idWaysTable AS a, 
+                ${osmTablesPrefix}_WAY_TAG AS b WHERE a.ID_WAY = b.ID_WAY AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                        info "Any columns to keep. Cannot create any geometry lines. An empty table will be returned."
+                        datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                        return [outputTableName: outputTableName]
+                    }}
+
 
                 datasource.execute """
                         DROP TABLE IF EXISTS $waysLinesTmp; 
@@ -541,8 +576,10 @@ IProcess extractRelationsAsLines() {
                 def tagsFilter = createWhereFilter(tags)
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
-                    warn "No keys or values found in the relations."
-                    return
+                    warn "No keys or values found in the relations. An empty table will be returned."
+                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    return [outputTableName: outputTableName]
                 }
                 def relationsLinesTmp = "RELATIONS_LINES_TMP_$uuid"
                 def RelationsFilteredKeys = "RELATION_FILTERED_KEYS_$uuid"
@@ -560,6 +597,15 @@ IProcess extractRelationsAsLines() {
                             CREATE INDEX ON $RelationsFilteredKeys(id_relation);
                     """
                 }
+
+                if(columnsToKeep){
+                    if(datasource.firstRow("""SELECT count(*) as count FROM $RelationsFilteredKeys AS a, 
+                ${osmTablesPrefix}_RELATION_TAG AS b WHERE a.ID_RELATION = b.ID_RELATION AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                        info "Any columns to keep. Cannot create any geometry lines. An empty table will be returned."
+                        datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
+                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                        return [outputTableName: outputTableName]
+                    }}
 
                 datasource.execute """
                         DROP TABLE IF EXISTS $relationsLinesTmp;

--- a/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/Transform.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/Transform.groovy
@@ -176,8 +176,10 @@ IProcess extractWaysAsPolygons() {
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
                     warn "No keys or values found to extract ways. An empty table will be returned."
-                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
-                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    datasource.execute """ 
+                            DROP TABLE IF EXISTS $outputTableName;
+                            CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                    """
                     return [outputTableName: outputTableName]
                 }
 
@@ -200,11 +202,16 @@ IProcess extractWaysAsPolygons() {
                 }
 
                 if(columnsToKeep){
-                    if(datasource.firstRow("""SELECT count(*) as count FROM $idWaysPolygons AS a, 
-                ${osmTablesPrefix}_WAY_TAG AS b WHERE a.ID_WAY = b.ID_WAY AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                    if(datasource.firstRow("""
+                            SELECT count(*) AS count 
+                            FROM $idWaysPolygons AS a, ${osmTablesPrefix}_WAY_TAG AS b 
+                            WHERE a.ID_WAY = b.ID_WAY AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')
+                    """)[0] < 1) {
                         info "Any columns to keep. Cannot create any geometry polygons. An empty table will be returned."
-                        datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
-                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                        datasource.execute """
+                                DROP TABLE IF EXISTS $outputTableName;
+                                CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                        """
                         return [outputTableName: outputTableName]
                     }}
 
@@ -282,8 +289,10 @@ IProcess extractRelationsAsPolygons() {
 
                 if (datasource.firstRow(countTagsQuery).count <= 0) {
                     warn "No keys or values found in the relations. An empty table will be returned."
-                    datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
-                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                    datasource.execute """
+                            DROP TABLE IF EXISTS $outputTableName;
+                            CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                    """
                     return [outputTableName: outputTableName]
                 }
                 info "Build outer polygons"
@@ -306,11 +315,16 @@ IProcess extractRelationsAsPolygons() {
                     """
 
                     if(columnsToKeep){
-                        if(datasource.firstRow("""SELECT count(*) as count FROM $relationFilteredKeys AS a, 
-                ${osmTablesPrefix}_RELATION_TAG AS b WHERE a.ID_RELATION = b.ID_RELATION AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                        if(datasource.firstRow("""
+                                SELECT count(*) AS count 
+                                FROM $relationFilteredKeys AS a, ${osmTablesPrefix}_RELATION_TAG AS b 
+                                WHERE a.ID_RELATION = b.ID_RELATION AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')
+                        """)[0]<1){
                             info "Any columns to keep. Cannot create any geometry polygons. An empty table will be returned."
-                            datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
-                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                            datasource.execute """
+                                    DROP TABLE IF EXISTS $outputTableName;
+                                    CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                            """
                             return [outputTableName: outputTableName]
                         }}
 
@@ -497,11 +511,16 @@ IProcess extractWaysAsLines() {
                 }
 
                 if(columnsToKeep){
-                    if(datasource.firstRow("""SELECT count(*) as count FROM $idWaysTable AS a, 
-                ${osmTablesPrefix}_WAY_TAG AS b WHERE a.ID_WAY = b.ID_WAY AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')""")[0]<1){
+                    if(datasource.firstRow("""
+                            SELECT count(*) AS count 
+                            FROM $idWaysTable AS a, ${osmTablesPrefix}_WAY_TAG AS b 
+                            WHERE a.ID_WAY = b.ID_WAY AND b.TAG_KEY IN ('${columnsToKeep.join("','")}')
+                    """)[0] < 1){
                         info "Any columns to keep. Cannot create any geometry lines. An empty table will be returned."
-                        datasource.execute """ DROP TABLE IF EXISTS $outputTableName;
-                        CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));"""
+                        datasource.execute """
+                                DROP TABLE IF EXISTS $outputTableName;
+                                CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                        """
                         return [outputTableName: outputTableName]
                     }}
 

--- a/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/utils/TransformUtils.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/utils/TransformUtils.groovy
@@ -265,12 +265,21 @@ class TransformUtils {
         def tagsFilter = createWhereFilter(tags)
 
         if (datasource.firstRow(countTagsQuery).count <= 0) {
-            info("No keys or values found in the nodes")
+            info("No keys or values found in the nodes. An empty table will be returned.")
+            datasource.execute """ DROP TABLE IF EXISTS $outputNodesPoints;
+                        CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));"""
             return false
         }
         info "Build nodes as points"
         def tagList = createTagList datasource, columnsSelector
         if (tagsFilter.isEmpty()) {
+            if (columnsToKeep) {
+                if (datasource.firstRow("select count(*) as count from $tableNodeTag where TAG_KEY in ('${columnsToKeep.join("','")}')")[0] < 1) {
+                    datasource.execute """ DROP TABLE IF EXISTS $outputNodesPoints;
+                        CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));"""
+                    return true
+                }
+            }
             datasource.execute """
                 DROP TABLE IF EXISTS $outputNodesPoints;
                 CREATE TABLE $outputNodesPoints AS
@@ -278,7 +287,15 @@ class TransformUtils {
                     FROM $tableNode AS a, $tableNodeTag b
                     WHERE a.id_node = b.id_node GROUP BY a.id_node;
             """
+
         } else {
+            if(columnsToKeep){
+                if(datasource.firstRow("select count(*) as count from $tableNodeTag where TAG_KEY in ('${columnsToKeep.join("','")}')")[0]<1){
+                    datasource.execute """ DROP TABLE IF EXISTS $outputNodesPoints;
+                        CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));"""
+                    return true
+                }
+            }
             def filteredNodes = "FILTERED_NODES_" + uuid()
             datasource.execute """
                 CREATE TABLE $filteredNodes AS
@@ -292,6 +309,7 @@ class TransformUtils {
                     AND a.id_node=c.id_node
                     GROUP BY a.id_node;
             """
+
         }
         return true
     }

--- a/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/utils/TransformUtils.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisanalysis/osm/utils/TransformUtils.groovy
@@ -266,8 +266,10 @@ class TransformUtils {
 
         if (datasource.firstRow(countTagsQuery).count <= 0) {
             info("No keys or values found in the nodes. An empty table will be returned.")
-            datasource.execute """ DROP TABLE IF EXISTS $outputNodesPoints;
-                        CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));"""
+            datasource.execute """
+                    DROP TABLE IF EXISTS $outputNodesPoints;
+                    CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));
+            """
             return false
         }
         info "Build nodes as points"
@@ -275,8 +277,10 @@ class TransformUtils {
         if (tagsFilter.isEmpty()) {
             if (columnsToKeep) {
                 if (datasource.firstRow("select count(*) as count from $tableNodeTag where TAG_KEY in ('${columnsToKeep.join("','")}')")[0] < 1) {
-                    datasource.execute """ DROP TABLE IF EXISTS $outputNodesPoints;
-                        CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));"""
+                    datasource.execute """
+                            DROP TABLE IF EXISTS $outputNodesPoints;
+                            CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));
+                    """
                     return true
                 }
             }
@@ -291,8 +295,10 @@ class TransformUtils {
         } else {
             if(columnsToKeep){
                 if(datasource.firstRow("select count(*) as count from $tableNodeTag where TAG_KEY in ('${columnsToKeep.join("','")}')")[0]<1){
-                    datasource.execute """ DROP TABLE IF EXISTS $outputNodesPoints;
-                        CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));"""
+                    datasource.execute """
+                            DROP TABLE IF EXISTS $outputNodesPoints;
+                            CREATE TABLE $outputNodesPoints (the_geom GEOMETRY(POINT,4326));
+                    """
                     return true
                 }
             }
@@ -309,7 +315,6 @@ class TransformUtils {
                     AND a.id_node=c.id_node
                     GROUP BY a.id_node;
             """
-
         }
         return true
     }

--- a/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/TransformTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/TransformTest.groovy
@@ -649,7 +649,7 @@ class TransformTest extends AbstractOSMTest {
     /**
      * It uses for test purpose
      */
-    //@Disabled
+    @Disabled
     @Test
     void dev() {
         H2GIS h2GIS = RANDOM_DS()

--- a/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/TransformTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/TransformTest.groovy
@@ -41,6 +41,7 @@ import org.locationtech.jts.geom.*
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.orbisgis.orbisanalysis.osm.utils.OSMElement
 
 import static org.junit.jupiter.api.Assertions.*
 
@@ -342,8 +343,8 @@ class TransformTest extends AbstractOSMTest {
 
         //Test not existing tags
         extractWaysAsPolygons = OSMTools.Transform.extractWaysAsPolygons()
-        assertFalse extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
-        assertTrue extractWaysAsPolygons.results.isEmpty()
+        assertTrue extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
+        assertTrue ds.getTable(extractWaysAsPolygons.results.outputTableName).isEmpty()
 
         //Test no tags
         extractWaysAsPolygons = OSMTools.Transform.extractWaysAsPolygons()
@@ -424,8 +425,8 @@ class TransformTest extends AbstractOSMTest {
 
         //Test not existing tags
         extractRelationsAsPolygons = OSMTools.Transform.extractRelationsAsPolygons()
-        assertFalse extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
-        assertTrue extractRelationsAsPolygons.results.isEmpty()
+        assertTrue extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
+        assertTrue ds.getTable(extractRelationsAsPolygons.results.outputTableName).isEmpty()
 
         //Test no tags
         extractRelationsAsPolygons = OSMTools.Transform.extractRelationsAsPolygons()
@@ -507,8 +508,8 @@ class TransformTest extends AbstractOSMTest {
 
         //Test not existing tags
         extractWaysAsLines = OSMTools.Transform.extractWaysAsLines()
-        assertFalse extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
-        assertTrue extractWaysAsLines.results.isEmpty()
+        assertTrue extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
+        assertTrue ds.getTable(extractWaysAsLines.results.outputTableName).isEmpty()
 
         //Test no tags
         extractWaysAsLines = OSMTools.Transform.extractWaysAsLines()
@@ -590,8 +591,8 @@ class TransformTest extends AbstractOSMTest {
 
         //Test not existing tags
         extractRelationsAsLines = OSMTools.Transform.extractRelationsAsLines()
-        assertFalse extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
-        assertTrue extractRelationsAsLines.results.isEmpty()
+        assertTrue extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:[toto:"tata"], columnsToKeep:[])
+        assertTrue ds.getTable(extractRelationsAsLines.results.outputTableName).isEmpty()
 
         //Test no tags
         extractRelationsAsLines = OSMTools.Transform.extractRelationsAsLines()
@@ -613,13 +614,46 @@ class TransformTest extends AbstractOSMTest {
     }
 
     /**
+     * Test the {@link org.orbisgis.orbisanalysis.osm.Transform#extractWaysAsLines()} process.
+     */
+    @Test
+    void extractWaysAsLinesWithoutResultsTest(){
+        def extractWaysAsLines = OSMTools.Transform.extractWaysAsLines()
+        H2GIS ds = RANDOM_DS()
+        def prefix = uuid()
+        def epsgCode = 2453
+        def tags = [building:"house"]
+        def columnsToKeep = ["landscape"]
+        createData(ds, prefix)
+        assertTrue extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
+        assertTrue ds.getTable(extractWaysAsLines.results.outputTableName).isEmpty()
+    }
+
+    /**
+     * Test the {@link org.orbisgis.orbisanalysis.osm.Transform#toPoints()} process.
+     */
+    @Test
+    void toPointsTestWithoutResults(){
+        def toPoints = OSMTools.Transform.toPoints()
+        H2GIS ds = RANDOM_DS()
+        def prefix = uuid()
+        def epsgCode = 2453
+        def tags = [building:"house"]
+        def columnsToKeep = ["landcover"]
+        createData(ds, prefix)
+        assertTrue toPoints(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
+        assertTrue ds.getTable(toPoints.results.outputTableName).isEmpty()
+    }
+
+
+    /**
      * It uses for test purpose
      */
-    @Disabled
+    //@Disabled
     @Test
     void dev() {
         H2GIS h2GIS = RANDOM_DS()
-        Geometry geom = OSMTools.Utilities.getAreaFromPlace("Boston");
+        Geometry geom = OSMTools.Utilities.getAreaFromPlace("Agadir");
         def query = OSMTools.Utilities.buildOSMQuery(geom.getEnvelopeInternal(), [], OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
         def extract = OSMTools.Loader.extract()
         if (!query.isEmpty()) {
@@ -636,4 +670,5 @@ class TransformTest extends AbstractOSMTest {
             }
         }
     }
+
 }

--- a/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/TransformTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/TransformTest.groovy
@@ -137,6 +137,11 @@ class TransformTest extends AbstractOSMTest {
         ds.execute "CREATE TABLE ${prefix}_node_tag (id_node int, tag_key varchar, tag_value varchar)"
         assertFalse toPoints(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
         assertTrue toPoints.results.isEmpty()
+        
+        //Test column to keep absent
+        toPoints = OSMTools.Transform.toPoints()
+        assertTrue toPoints(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landcover"])
+        assertTrue ds.getTable(toPoints.results.outputTableName).isEmpty()
     }
 
     /**
@@ -203,12 +208,17 @@ class TransformTest extends AbstractOSMTest {
             }
         }
 
-        //Test no points
-        toLines = OSMTools.Transform.toPoints()
+        //Test no lines
+        toLines = OSMTools.Transform.toLines()
         ds.execute "DROP TABLE ${prefix}_node_tag"
         ds.execute "CREATE TABLE ${prefix}_node_tag (id_node int, tag_key varchar, tag_value varchar)"
         assertFalse toLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
         assertTrue toLines.results.isEmpty()
+        
+        //Test column to keep absent
+        toLines = OSMTools.Transform.toLines()
+        assertTrue toLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landcover"])
+        assertTrue ds.getTable(toLines.results.outputTableName).isEmpty()
     }
 
     /**
@@ -275,12 +285,17 @@ class TransformTest extends AbstractOSMTest {
             }
         }
 
-        //Test no points
-        toPolygons = OSMTools.Transform.toPoints()
+        //Test no polygons
+        toPolygons = OSMTools.Transform.toPolygons()
         ds.execute "DROP TABLE ${prefix}_node_tag"
         ds.execute "CREATE TABLE ${prefix}_node_tag (id_node int, tag_key varchar, tag_value varchar)"
         assertFalse toPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
         assertTrue toPolygons.results.isEmpty()
+        
+        //Test column to keep absent
+        toPolygons = OSMTools.Transform.toPolygons()
+        assertTrue toPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landcover"])
+        assertTrue ds.getTable(toPolygons.results.outputTableName).isEmpty()
     }
 
     /**
@@ -363,6 +378,11 @@ class TransformTest extends AbstractOSMTest {
                     break
             }
         }
+        
+        //Test column to keep absent
+        extractWaysAsPolygons = OSMTools.Transform.extractWaysAsPolygons()
+        assertTrue extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landscape"])
+        assertTrue ds.getTable(extractWaysAsPolygons.results.outputTableName).isEmpty()
     }
 
     /**
@@ -445,6 +465,11 @@ class TransformTest extends AbstractOSMTest {
                     break
             }
         }
+        
+        //Test column to keep absent
+        extractRelationsAsPolygons = OSMTools.Transform.extractRelationsAsPolygons()
+        assertTrue extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landscape"])
+        assertTrue ds.getTable(extractRelationsAsPolygons.results.outputTableName).isEmpty()
     }
 
     /**
@@ -528,6 +553,11 @@ class TransformTest extends AbstractOSMTest {
                     break
             }
         }
+        
+        //Test column to keep absent
+        extractWaysAsLines = OSMTools.Transform.extractWaysAsLines()
+        assertTrue extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landscape"])
+        assertTrue ds.getTable(extractWaysAsLines.results.outputTableName).isEmpty()
     }
 
     /**
@@ -611,38 +641,11 @@ class TransformTest extends AbstractOSMTest {
                     break
             }
         }
-    }
-
-    /**
-     * Test the {@link org.orbisgis.orbisanalysis.osm.Transform#extractWaysAsLines()} process.
-     */
-    @Test
-    void extractWaysAsLinesWithoutResultsTest(){
-        def extractWaysAsLines = OSMTools.Transform.extractWaysAsLines()
-        H2GIS ds = RANDOM_DS()
-        def prefix = uuid()
-        def epsgCode = 2453
-        def tags = [building:"house"]
-        def columnsToKeep = ["landscape"]
-        createData(ds, prefix)
-        assertTrue extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
-        assertTrue ds.getTable(extractWaysAsLines.results.outputTableName).isEmpty()
-    }
-
-    /**
-     * Test the {@link org.orbisgis.orbisanalysis.osm.Transform#toPoints()} process.
-     */
-    @Test
-    void toPointsTestWithoutResults(){
-        def toPoints = OSMTools.Transform.toPoints()
-        H2GIS ds = RANDOM_DS()
-        def prefix = uuid()
-        def epsgCode = 2453
-        def tags = [building:"house"]
-        def columnsToKeep = ["landcover"]
-        createData(ds, prefix)
-        assertTrue toPoints(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
-        assertTrue ds.getTable(toPoints.results.outputTableName).isEmpty()
+        
+        //Test column to keep absent
+        extractRelationsAsLines = OSMTools.Transform.extractRelationsAsLines()
+        assertTrue extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:["landscape"])
+        assertTrue ds.getTable(extractRelationsAsLines.results.outputTableName).isEmpty()
     }
 
 

--- a/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/utils/TransformUtilsTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisanalysis/osm/utils/TransformUtilsTest.groovy
@@ -1096,9 +1096,9 @@ class TransformUtilsTest extends AbstractOSMTest {
         ds.execute "CREATE TABLE ${prefix}_relation_tag (id_relation int, tag_key varchar, tag_value varchar)"
 
         result = TransformUtils.toPolygonOrLine(polygonType, ds, prefix, epsgCode, tags, columnsToKeep)
-        assertNull result
+        assertNotNull result
 
         result = TransformUtils.toPolygonOrLine(lineType, ds, prefix, epsgCode, tags, columnsToKeep)
-        assertNull result
+        assertNotNull result
     }
 }


### PR DESCRIPTION
About https://github.com/orbisgis/orbisanalysis/issues/55

 OSM module now check correctly the list of columns to keep.

If there is no columns in the result table, we create an empty table.
An empty table is also created when osm file doesn't contain any valid tags.

